### PR TITLE
Fixed the link to 'The-4-ways-to-Break-into-Product-Management'

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Open-Product-Management is an amazing list for people who need a refresher in Pr
  * [Do Product Managers really need a background in CS](https://pmblog.quora.com/Do-Product-Managers-really-need-a-background-in-CS) - Jackie Bavaro
  * [Want to be a PM? Do a Project](http://blog.ellenchisa.com/2014/01/28/want-to-be-a-pm-do-a-project/) - Ellen Chisa
  * [So You Want to Manage a Product](https://medium.com/@rohinivibha/so-you-want-to-manage-a-product-c664ba7e5138) - Rohini Viba
- * [The 4 ways to break into Product Management](https://pmblog.quora.com/Do-Product-Managers-really-need-a-background-in-CS) - Jackie Bavaro
+ * [The 4 ways to break into Product Management](https://pmblog.quora.com/The-4-ways-to-Break-into-Product-Management) - Jackie Bavaro
  * [12 things Product Managers should do in their first 30 Days at a new company](http://www.gv.com/lib/12-things-product-managers-should-do-in-their-first-30-days-at-a-new-company) - Kenneth Norton
  * [Evolution of the Product Manager](http://queue.acm.org/detail.cfm?id=2683579) - Ellen Chisa
  * [4 mistakes new Product Managers make](http://dev.hubspot.com/blog/4-mistakes-new-product-managers-make) - Matt Schnitt


### PR DESCRIPTION
It was linking to another blog post by the same author (which is already coreectly linked to elsewhere in the list.)